### PR TITLE
Add automated Diia.Business story scraper and parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,140 @@
-- 👋 Hi, I’m @MixaJuba
-- 👀 I’m interested in GPT Lawyer UA
-- 🌱 I’m currently I study programming, but stupid Russian pigs wanted to kill me. Now I kill them! And I program lawyers)
-- 💞️ I want to cooperate with lawyers and, of course, people similar to me
-##- 💞️ Я хочу співпрацювати з юристами і звісно ж собі схожих 
-- 📫 How to get to me... ? There are a couple of options, a couple of tropes. The main thing is to DO what you WANT. Do you understand me? It's not enough to want... You have to get up and do it, SEW!
-##- 📫 Як до мене доїхати... ? Є пару варіантів, пару троп.  Головне РОБИТИ те що ти ХОЧЕШ. Розумієш  мене да ? Хотіти мало... Треба вставати і робити, ЇБОШИТь !
+# Diia.Business Success Story Scraper
 
-<!---              
-MixaJuba/MixaJuba is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This repository now contains a production-ready Python utility that collects
+Ukrainian business success stories from
+[Diia.Business](https://business.diia.gov.ua/history-of-success), normalises the
+content into analytical blocks, and exports results to both JSON and CSV for
+further research.
+
+## Key features
+- **Ethical scraping workflow** – configurable delay, robots.txt check, custom
+  user-agent, and graceful error handling.
+- **Heuristic structuring engine** – stories are automatically segmented into
+  nine analytical blocks (introduction, case description, challenges, etc.)
+  using multilingual keyword detection with positional fallbacks.
+- **Quality controls** – empty blocks are flagged for manual audit to prevent
+  silent data loss.
+- **Flexible exports** – helper utilities produce machine-readable JSON and
+  analyst-friendly wide CSV tables.
+- **Unit-tested codebase** – `python -m unittest` runs deterministic tests with
+  fake HTTP sessions; no live requests are issued during CI.
+
+## Project layout
+
+```
+├── diia_scraper/
+│   ├── cli.py              # CLI entry point (argparse-based)
+│   ├── scraper.py          # Network orchestration & export helpers
+│   ├── story_parser.py     # Heuristic text segmentation logic
+│   └── validation.py       # Block-level quality checks
+├── tests/                  # Unit tests (no external dependencies)
+├── requirements.txt        # Runtime dependencies
+└── README.md
+```
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+> **Tip:** Pin dependencies in your production environment to avoid changes in
+> HTML parsing behaviour when upstream libraries release updates.
+
+## Usage
+
+```bash
+python -m diia_scraper.cli --limit 3 --output-dir output --delay 1.5 --verbose
+```
+
+The command above downloads the first three success stories (subject to
+network/robots.txt restrictions), structures them, and writes two files:
+
+- `output/stories.json` – nested JSON with metadata, block texts, and validation
+  notes.
+- `output/stories.csv` – flat table convenient for spreadsheets or BI tools.
+
+### Custom keyword dictionaries
+
+Create a JSON file where keys are block names and values are keyword lists, e.g.:
+
+```json
+{
+  "Introduction": ["intro", "початок"],
+  "Audit": ["провали", "gap"]
+}
+```
+
+Then run:
+
+```bash
+python -m diia_scraper.cli --keywords keywords.json
+```
+
+Missing blocks will still be assigned via fallback ordering, but custom keywords
+allow you to tailor detection for niche industries or internal terminology.
+
+## Scheduling & extensions
+
+- **Cron** – wrap the CLI in a shell script and add an entry to `crontab -e`
+  (e.g. `0 6 * * 1` for a weekly run). Persist output timestamps if you need
+  change tracking.
+- **Apache Airflow** – load `DiiaBusinessScraper` inside a PythonOperator task to
+  integrate with existing ETL pipelines. Use XCom to push JSON payloads.
+- **Google Sheets / Notion** – export the CSV to Google Drive via
+  [`gspread`](https://github.com/burnash/gspread) or sync to Notion using the
+  official [Notion API](https://developers.notion.com/docs/getting-started).
+
+## Best practices
+
+1. **Respect robots.txt** – run the built-in `check_robots_allowance()` before
+   scraping or configure mirrors for private datasets.
+2. **Rate limiting** – adjust `--delay` if the portal enforces stricter limits.
+3. **Network resilience** – wrap production runs with retry logic (e.g.
+   [`tenacity`](https://github.com/jd/tenacity)) and persistent caching (e.g.
+   [`requests-cache`](https://requests-cache.readthedocs.io/en/stable/)).
+4. **Content drift** – HTML structure may change; extend
+   `_extract_story_text()` selectors and add regression tests with fixture HTML.
+5. **NLP upgrades** – swap the heuristic parser for
+   [spaCy](https://spacy.io/usage) text classification, a
+   [LangChain](https://python.langchain.com/docs/) Structured Output Parser, or
+   zero-shot models from [Hugging Face Transformers](https://huggingface.co/docs/transformers/index)
+   if higher recall is required.
+
+## Testing
+
+```bash
+python -m unittest
+```
+
+Tests rely on fake HTML responses, so they are fast and repeatable. For
+additional validation, you can add doctests or golden-file comparisons for real
+stories once network access is available.
+
+## Troubleshooting
+
+- **403/Proxy errors** – the official domain may block certain regions. Deploy
+  the scraper within Ukrainian infrastructure or configure approved corporate
+  proxies.
+- **Empty exports** – ensure the listing URL has stories (pagination can be
+  handled by calling `scrape()` again with an offset or extending
+  `_fetch_story_links`).
+- **Encoding issues** – all exports use UTF-8; if your downstream system expects
+  Windows-1251, convert via `iconv` or `pandas.DataFrame.to_csv(encoding="cp1251")`.
+
+## Contribution ideas
+
+- Add pagination awareness by crawling the `aria-label="next"` button.
+- Integrate a caching layer to avoid re-downloading unchanged stories.
+- Store raw HTML snapshots for reproducibility and auditing.
+- Provide optional summarisation via open-source LLMs (e.g. `ukr-large` models)
+  with GPU-friendly inference stacks such as
+  [AutoGPTQ](https://github.com/PanQiWei/AutoGPTQ) for quantised deployment.
+
+## License
+
+This project builds upon public information available on the Diia.Business
+portal. Review local regulations and the website's terms of use before
+redistributing scraped content.

--- a/diia_scraper/__init__.py
+++ b/diia_scraper/__init__.py
@@ -1,0 +1,16 @@
+"""Utility package for scraping and structuring Diia.Business success stories."""
+
+from .scraper import DiiaBusinessScraper, StructuredStory, export_to_csv, export_to_json
+from .story_parser import BLOCK_ORDER, DEFAULT_KEYWORD_MAP, parse_story
+from .validation import assess_story_blocks
+
+__all__ = [
+    "DiiaBusinessScraper",
+    "StructuredStory",
+    "export_to_csv",
+    "export_to_json",
+    "BLOCK_ORDER",
+    "DEFAULT_KEYWORD_MAP",
+    "parse_story",
+    "assess_story_blocks",
+]

--- a/diia_scraper/cli.py
+++ b/diia_scraper/cli.py
@@ -1,0 +1,97 @@
+"""Command-line interface for Diia.Business story scraping."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict
+
+from .scraper import DiiaBusinessScraper
+from .story_parser import DEFAULT_CONFIG, ParserConfig
+
+
+def _load_keyword_map(path: Path) -> Dict[str, list[str]]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+        if not isinstance(data, dict):
+            raise ValueError("Keyword override must be a JSON object")
+        return {str(k): list(v) for k, v in data.items()}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Scrape Diia.Business success stories")
+    parser.add_argument("--limit", type=int, default=3, help="Number of stories to download (default: 3)")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output"),
+        help="Directory for JSON/CSV exports",
+    )
+    parser.add_argument(
+        "--keywords",
+        type=Path,
+        help="Path to JSON file with custom keyword map (block -> list of keywords)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=1.0,
+        help="Delay between HTTP requests in seconds",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="HTTP request timeout in seconds",
+    )
+    parser.add_argument(
+        "--base-url",
+        type=str,
+        default="https://business.diia.gov.ua",
+        help="Override base URL (useful for mirrors or testing)",
+    )
+    parser.add_argument(
+        "--listing-path",
+        type=str,
+        default="/history-of-success",
+        help="Override listing path",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_parser()
+    options = parser.parse_args(args=args)
+
+    logging.basicConfig(level=logging.DEBUG if options.verbose else logging.INFO)
+
+    parser_config = DEFAULT_CONFIG
+    if options.keywords:
+        keyword_map = _load_keyword_map(options.keywords)
+        parser_config = ParserConfig(block_order=DEFAULT_CONFIG.block_order, keyword_map=keyword_map)
+
+    scraper = DiiaBusinessScraper(
+        base_url=options.base_url,
+        listing_path=options.listing_path,
+        parser_config=parser_config,
+        request_delay=options.delay,
+        request_timeout=options.timeout,
+    )
+
+    if not scraper.check_robots_allowance():
+        logging.warning("Scraping may be disallowed by robots.txt – review before proceeding.")
+
+    stories = scraper.scrape(limit=options.limit)
+    if not stories:
+        logging.error("No stories were scraped. Check network connectivity or URL settings.")
+        return
+
+    outputs = scraper.export(stories, options.output_dir)
+    logging.info("Exported %s stories to JSON: %s and CSV: %s", len(stories), outputs["json"], outputs["csv"])
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/diia_scraper/scraper.py
+++ b/diia_scraper/scraper.py
@@ -1,0 +1,248 @@
+"""Scraper orchestrating Diia.Business success story extraction."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urljoin
+import urllib.robotparser
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+from .story_parser import ParserConfig, DEFAULT_CONFIG, parse_story
+from .validation import ValidationResult, assess_story_blocks
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class StructuredStory:
+    """Normalised representation of a success story."""
+
+    title: str
+    url: str
+    blocks: Dict[str, str]
+    validation: ValidationResult
+    raw_text: str = ""
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def to_serialisable_dict(self) -> Dict[str, object]:
+        """Return a JSON-serialisable representation of the story."""
+
+        payload = asdict(self)
+        payload["validation"] = {
+            "missing_blocks": self.validation.missing_blocks,
+            "needs_review": self.validation.needs_review,
+            "notes": self.validation.notes,
+        }
+        return payload
+
+    def to_flat_record(self) -> Dict[str, str]:
+        """Flatten nested structure for CSV export."""
+
+        record = {
+            "title": self.title,
+            "url": self.url,
+            "needs_review": str(self.validation.needs_review),
+            "missing_blocks": ", ".join(self.validation.missing_blocks),
+        }
+        record.update({block: text for block, text in self.blocks.items()})
+        return record
+
+
+class DiiaBusinessScraper:
+    """Scrape and structure success stories from business.diia.gov.ua."""
+
+    def __init__(
+        self,
+        base_url: str = "https://business.diia.gov.ua",
+        listing_path: str = "/history-of-success",
+        *,
+        session: Optional[requests.Session] = None,
+        parser_config: ParserConfig = DEFAULT_CONFIG,
+        request_delay: float = 1.0,
+        request_timeout: int = 30,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.listing_path = listing_path
+        self.session = session or requests.Session()
+        self.session.headers.setdefault(
+            "User-Agent",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0 Safari/537.36",
+        )
+        self.parser_config = parser_config
+        self.request_delay = request_delay
+        self.request_timeout = request_timeout
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def scrape(self, limit: int = 3) -> List[StructuredStory]:
+        """Scrape and structure a limited number of success stories."""
+
+        links = self._fetch_story_links(limit)
+        stories: List[StructuredStory] = []
+
+        for index, url in enumerate(links, start=1):
+            try:
+                LOGGER.info("Fetching story %s/%s: %s", index, len(links), url)
+                html = self._get(url)
+                soup = BeautifulSoup(html, "html.parser")
+                title = self._extract_title(soup) or "Untitled story"
+                raw_text = self._extract_story_text(soup)
+                blocks = parse_story(raw_text, self.parser_config)
+                validation = assess_story_blocks(blocks, self.parser_config.block_order)
+                stories.append(
+                    StructuredStory(
+                        title=title,
+                        url=url,
+                        blocks=blocks,
+                        validation=validation,
+                        raw_text=raw_text,
+                        metadata={"fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+                    )
+                )
+            except requests.RequestException as exc:
+                LOGGER.error("Failed to download %s: %s", url, exc)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.exception("Unexpected error while processing %s: %s", url, exc)
+
+            time.sleep(self.request_delay)
+
+        return stories
+
+    def check_robots_allowance(self) -> bool:
+        """Return True if scraping the listing path is allowed by robots.txt."""
+
+        robots_url = urljoin(f"{self.base_url}/", "robots.txt")
+        parser = urllib.robotparser.RobotFileParser()
+        try:
+            parser.set_url(robots_url)
+            parser.read()
+        except Exception as exc:  # pragma: no cover - network failure resilience
+            LOGGER.warning("Could not read robots.txt (%s): %s", robots_url, exc)
+            return False
+        return parser.can_fetch(self.session.headers.get("User-Agent", "*"), urljoin(self.base_url, self.listing_path))
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+    def export(self, stories: Iterable[StructuredStory], output_dir: Path) -> Dict[str, Path]:
+        """Export structured stories to JSON and CSV."""
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        stories_list = list(stories)
+        json_path = output_dir / "stories.json"
+        csv_path = output_dir / "stories.csv"
+        export_to_json(stories_list, json_path)
+        export_to_csv(stories_list, csv_path)
+        return {"json": json_path, "csv": csv_path}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _fetch_story_links(self, limit: int) -> List[str]:
+        """Return absolute URLs for the latest success stories."""
+
+        listing_url = urljoin(self.base_url, self.listing_path)
+        html = self._get(listing_url)
+        soup = BeautifulSoup(html, "html.parser")
+        links = self._extract_links_from_listing(soup)
+        absolute_links = [urljoin(self.base_url, link) for link in links]
+        return absolute_links[:limit]
+
+    def _extract_links_from_listing(self, soup: BeautifulSoup) -> List[str]:
+        """Extract story hyperlinks from the listing page."""
+
+        candidates = []
+        for selector in [
+            "a.article-card",
+            "a.card",
+            "a.story-card",
+            "article a",
+        ]:
+            for anchor in soup.select(selector):
+                href = anchor.get("href")
+                if href and href not in candidates:
+                    candidates.append(href)
+            if candidates:
+                break
+
+        # Fallback: look for anchors containing the listing path slug.
+        if not candidates:
+            for anchor in soup.find_all("a"):
+                href = anchor.get("href") or ""
+                if "history" in href and href not in candidates:
+                    candidates.append(href)
+        return candidates
+
+    def _extract_title(self, soup: BeautifulSoup) -> Optional[str]:
+        """Extract the title (h1) from a story page."""
+
+        title_tag = soup.find("h1")
+        if title_tag:
+            return title_tag.get_text(strip=True)
+        return None
+
+    def _extract_story_text(self, soup: BeautifulSoup) -> str:
+        """Extract the main textual content from a story page."""
+
+        containers = [
+            "article",
+            "div.article",
+            "div.post-content",
+            "div.article-content",
+            "div.blog-single",
+            "main",
+        ]
+        for selector in containers:
+            element = soup.select_one(selector)
+            if element:
+                paragraphs = [
+                    p.get_text(" ", strip=True)
+                    for p in element.find_all(["p", "li", "blockquote", "h2", "h3"])
+                ]
+                text = "\n\n".join(filter(None, paragraphs))
+                if text.strip():
+                    return text
+        # Ultimate fallback – entire page text.
+        return soup.get_text(" ", strip=True)
+
+    def _get(self, url: str) -> str:
+        """Perform an HTTP GET with error handling."""
+
+        response = self.session.get(url, timeout=self.request_timeout)
+        response.raise_for_status()
+        return response.text
+
+
+# ----------------------------------------------------------------------
+# Standalone exporters
+# ----------------------------------------------------------------------
+
+def export_to_json(stories: Iterable[StructuredStory], path: Path) -> Path:
+    """Export structured stories to a JSON file."""
+
+    serialised = [story.to_serialisable_dict() for story in stories]
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(serialised, fh, ensure_ascii=False, indent=2)
+    return path
+
+
+def export_to_csv(stories: Iterable[StructuredStory], path: Path) -> Path:
+    """Export structured stories to CSV (wide format)."""
+
+    rows = [story.to_flat_record() for story in stories]
+    df = pd.DataFrame(rows)
+    df.to_csv(path, index=False)
+    return path
+
+
+__all__ = ["DiiaBusinessScraper", "StructuredStory", "export_to_json", "export_to_csv"]

--- a/diia_scraper/story_parser.py
+++ b/diia_scraper/story_parser.py
@@ -1,0 +1,281 @@
+"""Story parsing helpers for Diia.Business success cases.
+
+The parser is intentionally heuristic: it searches for section-like headings in
+Ukrainian/English and gracefully falls back to positional assignment when
+headings are absent. The goal is to standardise content for downstream
+analytics without relying on heavy NLP dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+# Canonical order of analytic blocks requested by the user.
+BLOCK_ORDER: List[str] = [
+    "Introduction",
+    "Case Description",
+    "Challenges",
+    "Solutions Found",
+    "Effectiveness Analysis",
+    "Resources and Tools",
+    "Self-analysis",
+    "General Conclusions",
+    "Audit",
+]
+
+# Default keyword map mixes Ukrainian and English markers frequently found in
+# Diia.Business publications. The structure is customisable at runtime.
+DEFAULT_KEYWORD_MAP: Dict[str, List[str]] = {
+    "Introduction": [
+        "вступ",
+        "коротка суть",
+        "мета",
+        "навіщо",
+        "огляд",
+        "introduction",
+        "summary",
+        "purpose",
+    ],
+    "Case Description": [
+        "опис кейсу",
+        "стартові умови",
+        "передумови",
+        "ринок",
+        "інвестиції",
+        "команда",
+        "case description",
+        "background",
+        "initial conditions",
+    ],
+    "Challenges": [
+        "труднощі",
+        "виклики",
+        "бар'єри",
+        "obstacles",
+        "challenges",
+        "pain point",
+    ],
+    "Solutions Found": [
+        "рішення",
+        "стратегія",
+        "кроки",
+        "дії",
+        "implementation",
+        "solutions",
+    ],
+    "Effectiveness Analysis": [
+        "аналіз ефективності",
+        "результати",
+        "success",
+        "невдачі",
+        "lessons",
+        "impact",
+    ],
+    "Resources and Tools": [
+        "ресурси",
+        "інструменти",
+        "технології",
+        "платформи",
+        "toolkit",
+        "partners",
+    ],
+    "Self-analysis": [
+        "самоаналіз",
+        "цитати",
+        "висновки підприємця",
+        "reflection",
+        "quote",
+        "entrepreneur",
+    ],
+    "General Conclusions": [
+        "узагальнені висновки",
+        "висновки",
+        "рекомендації",
+        "тенденції",
+        "conclusion",
+        "advice",
+        "recommendations",
+    ],
+    "Audit": [
+        "аудит",
+        "контрольні питання",
+        "сліпі плями",
+        "прогалини",
+        "audit",
+        "risks",
+    ],
+}
+
+# Regex helpers reused by the parser.
+_MULTISPACE = re.compile(r"\s+", re.UNICODE)
+_WORD_NORMALISER = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+@dataclass(frozen=True)
+class ParserConfig:
+    """Configuration for keyword-driven block detection."""
+
+    block_order: Iterable[str]
+    keyword_map: Dict[str, Iterable[str]]
+    heading_max_words: int = 12
+
+    def as_json(self) -> str:
+        """Serialise the config to JSON (useful for debugging/export)."""
+
+        payload = {
+            "block_order": list(self.block_order),
+            "keyword_map": {k: list(v) for k, v in self.keyword_map.items()},
+            "heading_max_words": self.heading_max_words,
+        }
+        return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+DEFAULT_CONFIG = ParserConfig(block_order=BLOCK_ORDER, keyword_map=DEFAULT_KEYWORD_MAP)
+
+
+def parse_story(text: str, config: ParserConfig | None = None) -> Dict[str, str]:
+    """Split a success story into analytical blocks.
+
+    Args:
+        text: Full story body (with optional headings).
+        config: Optional override for the parser configuration.
+
+    Returns:
+        Ordered dictionary-like mapping (Python ``dict`` preserves insertion
+        order) where keys match ``config.block_order`` and values contain block
+        content. Missing sections are represented by empty strings.
+    """
+
+    cfg = config or DEFAULT_CONFIG
+    ordered_blocks = list(cfg.block_order)
+    keyword_map = {k: list(v) for k, v in cfg.keyword_map.items()}
+    normalised_text = re.sub(r"\r\n?", "\n", text or "").strip()
+    if not normalised_text:
+        return {block: "" for block in ordered_blocks}
+
+    sections = _extract_sections(normalised_text, cfg)
+    result: Dict[str, str] = {block: "" for block in ordered_blocks}
+    fallback_index = 0
+
+    for block_hint, content in sections:
+        if not content:
+            continue
+
+        if block_hint in result:
+            target_block = block_hint
+            fallback_index = max(fallback_index, ordered_blocks.index(target_block))
+        else:
+            target_block, fallback_index = _assign_fallback(result, ordered_blocks, fallback_index)
+
+        existing = result[target_block]
+        result[target_block] = f"{existing}\n\n{content}".strip() if existing else content
+
+    return result
+
+
+def _assign_fallback(current: Dict[str, str], order: List[str], start: int) -> Tuple[str, int]:
+    """Pick the next empty block in canonical order."""
+
+    for idx in range(start, len(order)):
+        block = order[idx]
+        if not current[block]:
+            return block, idx
+    return order[-1], len(order) - 1
+
+
+def _extract_sections(text: str, config: ParserConfig) -> List[Tuple[Optional[str], str]]:
+    """Extract candidate sections with potential block names."""
+
+    paragraphs = [p.strip() for p in re.split(r"\n{2,}", text) if p.strip()]
+    sections: List[Tuple[Optional[str], str]] = []
+    active_block: Optional[str] = None
+
+    for paragraph in paragraphs:
+        lines = [ln.strip() for ln in paragraph.splitlines() if ln.strip()]
+        if not lines:
+            continue
+
+        block, inline_content = _detect_heading(lines[0], config)
+        if block:
+            # Start a new block; reuse inline content if heading contains text.
+            body_lines = []
+            if inline_content:
+                body_lines.append(inline_content)
+            if len(lines) > 1:
+                body_lines.extend(lines[1:])
+            sections.append((block, "\n".join(body_lines).strip()))
+            active_block = block
+        else:
+            sections.append((active_block, "\n".join(lines)))
+
+    # Merge consecutive sections that belong to the same block to avoid
+    # splitting paragraphs unnecessarily.
+    merged: List[Tuple[Optional[str], str]] = []
+    for block, content in sections:
+        if merged and merged[-1][0] == block and block is not None:
+            prev_block, prev_content = merged[-1]
+            merged[-1] = (prev_block, f"{prev_content}\n\n{content}".strip())
+        else:
+            merged.append((block, content))
+    return merged
+
+
+def _detect_heading(line: str, config: ParserConfig) -> Tuple[Optional[str], str]:
+    """Attempt to interpret a line as a heading and return the block match."""
+
+    stripped = line.strip()
+    if not stripped:
+        return None, ""
+
+    for separator in (":", "—", "–", "-", "."):
+        if separator in stripped:
+            potential, tail = stripped.split(separator, 1)
+            block = _evaluate_heading_candidate(potential, config)
+            if block:
+                return block, tail.strip()
+
+    block = _evaluate_heading_candidate(stripped, config)
+    return block, ""
+
+
+def _evaluate_heading_candidate(candidate: str, config: ParserConfig) -> Optional[str]:
+    """Check if candidate string matches any configured keyword."""
+
+    candidate = candidate.strip()
+    if not candidate:
+        return None
+
+    if not _looks_like_heading(candidate, config.heading_max_words):
+        return None
+
+    normalised = _MULTISPACE.sub(" ", _WORD_NORMALISER.sub(" ", candidate.lower())).strip()
+    tokens = set(normalised.split())
+
+    for block, keywords in config.keyword_map.items():
+        for keyword in keywords:
+            keyword = keyword.lower()
+            if " " in keyword:
+                if keyword in normalised:
+                    return block
+            elif keyword in tokens:
+                return block
+    return None
+
+
+def _looks_like_heading(text: str, max_words: int) -> bool:
+    """Heuristic: treat short lines as potential headings."""
+
+    words = text.split()
+    return 0 < len(words) <= max_words
+
+
+__all__ = [
+    "BLOCK_ORDER",
+    "DEFAULT_KEYWORD_MAP",
+    "ParserConfig",
+    "DEFAULT_CONFIG",
+    "parse_story",
+]

--- a/diia_scraper/validation.py
+++ b/diia_scraper/validation.py
@@ -1,0 +1,41 @@
+"""Validation utilities for structured success stories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Captures validation metadata for a structured story."""
+
+    missing_blocks: List[str]
+    needs_review: bool
+    notes: Dict[str, str]
+
+
+def assess_story_blocks(blocks: Dict[str, str], required_blocks: Iterable[str]) -> ValidationResult:
+    """Check whether the story contains data in all required blocks.
+
+    Args:
+        blocks: Mapping of analytic blocks to extracted content.
+        required_blocks: Iterable of blocks considered mandatory.
+
+    Returns:
+        ``ValidationResult`` listing missing blocks and review notes.
+    """
+
+    missing: List[str] = []
+    notes: Dict[str, str] = {}
+
+    for block in required_blocks:
+        value = blocks.get(block, "")
+        if not value or not value.strip():
+            missing.append(block)
+            notes[block] = "Empty block – requires manual fact-checking."
+
+    return ValidationResult(missing_blocks=missing, needs_review=bool(missing), notes=notes)
+
+
+__all__ = ["ValidationResult", "assess_story_blocks"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4>=4.14.0
+pandas>=2.3.2
+requests>=2.32.0

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+import unittest
+
+import pandas as pd
+
+from diia_scraper.scraper import DiiaBusinessScraper, StructuredStory
+from diia_scraper.story_parser import DEFAULT_CONFIG
+
+
+class FakeResponse:
+    def __init__(self, text: str, status_code: int = 200) -> None:
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if not (200 <= self.status_code < 400):
+            raise Exception(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self, mapping: Dict[str, str]) -> None:
+        self.mapping = mapping
+        self.headers: Dict[str, str] = {}
+
+    def get(self, url: str, timeout: int | None = None) -> FakeResponse:
+        if url not in self.mapping:
+            raise AssertionError(f"Unexpected URL: {url}")
+        return FakeResponse(self.mapping[url])
+
+
+LISTING_HTML = """
+<html><body>
+<a class="article-card" href="/history-of-success/story-1">Story 1</a>
+<a class="article-card" href="/history-of-success/story-2">Story 2</a>
+</body></html>
+"""
+
+STORY_HTML = """
+<html><body>
+<main>
+<h1>Test Story</h1>
+<p>Вступ: Короткий вступ.</p>
+<p>Стартові умови: Бюджет 1000 доларів.</p>
+<p>Труднощі: Не вистачає клієнтів.</p>
+<p>Рішення: Запуск реклами.</p>
+<p>Аналіз ефективності: Збільшення продажів.</p>
+<p>Ресурси: CRM, CRM.</p>
+<p>Самоаналіз: "Ми навчилися працювати з даними".</p>
+<p>Висновки: Масштабування поступове.</p>
+<p>Аудит: Потрібні додаткові метрики.</p>
+</main>
+</body></html>
+"""
+
+
+class ScraperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        mapping = {
+            "https://business.diia.gov.ua/history-of-success": LISTING_HTML,
+            "https://business.diia.gov.ua/history-of-success/story-1": STORY_HTML,
+            "https://business.diia.gov.ua/history-of-success/story-2": STORY_HTML,
+        }
+        self.scraper = DiiaBusinessScraper(session=FakeSession(mapping), parser_config=DEFAULT_CONFIG)
+        self.tmp_dir = Path("tests/tmp")
+        if self.tmp_dir.exists():
+            for file in self.tmp_dir.iterdir():
+                file.unlink()
+        else:
+            self.tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        if self.tmp_dir.exists():
+            for file in self.tmp_dir.iterdir():
+                file.unlink()
+            self.tmp_dir.rmdir()
+
+    def test_scraper_collects_structured_stories(self) -> None:
+        stories = self.scraper.scrape(limit=2)
+        self.assertEqual(len(stories), 2)
+        self.assertTrue(all(isinstance(story, StructuredStory) for story in stories))
+        self.assertEqual(stories[0].validation.missing_blocks, [])
+
+    def test_export_creates_json_and_csv(self) -> None:
+        stories = self.scraper.scrape(limit=1)
+        outputs = self.scraper.export(stories, self.tmp_dir)
+        self.assertTrue(outputs["json"].exists())
+        self.assertTrue(outputs["csv"].exists())
+        with outputs["json"].open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        self.assertEqual(len(data), 1)
+        df = pd.read_csv(outputs["csv"])
+        self.assertFalse(df.empty)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_story_parser.py
+++ b/tests/test_story_parser.py
@@ -1,0 +1,56 @@
+import unittest
+
+from diia_scraper.story_parser import DEFAULT_CONFIG, ParserConfig, parse_story
+
+
+SAMPLE_TEXT = """
+Вступ: Мета кейсу — перевести офлайн-продажі в онлайн.
+
+Стартові умови
+Ринок перенасичений, команда з трьох людей, бюджет 5000 доларів.
+
+Труднощі: Відсутність довіри клієнтів.
+
+Знайдені рішення
+Запустили контент-маркетинг та партнерство з локальними медіа.
+
+Аналіз ефективності
+Перші два місяці без зростання, але згодом стабільний приріст 15%.
+
+Ресурси та інструменти
+CRM, email-розсилки, консультації менторів.
+
+Самоаналіз
+"Ми недооцінили силу простих рекомендацій" — засновник.
+
+Узагальнені висновки
+Регулярна робота з відгуками — ключ до масштабування.
+
+Аудит
+Не розкрито роботу з безпекою даних.
+"""
+
+
+class StoryParserTests(unittest.TestCase):
+    def test_parse_story_detects_all_blocks(self) -> None:
+        parsed = parse_story(SAMPLE_TEXT)
+        for block in DEFAULT_CONFIG.block_order:
+            self.assertTrue(parsed[block])
+
+    def test_parse_story_fallback_without_headings(self) -> None:
+        text = "Перша частина кейсу.\n\nДругий абзац пояснює старт.\n\nТретій параграф про проблеми."
+        parsed = parse_story(text)
+        self.assertTrue(parsed["Introduction"].startswith("Перша частина"))
+        self.assertTrue(parsed["Case Description"].startswith("Другий"))
+        self.assertIn("Третій", parsed["Challenges"])
+
+    def test_custom_keyword_configuration(self) -> None:
+        custom_map = {block: list(keywords) for block, keywords in DEFAULT_CONFIG.keyword_map.items()}
+        custom_map["Introduction"] = ["intro"]
+        config = ParserConfig(block_order=DEFAULT_CONFIG.block_order, keyword_map=custom_map)
+        parsed = parse_story("Intro: Custom content", config=config)
+        self.assertTrue(parsed["Introduction"].startswith("Custom content"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,21 @@
+import unittest
+
+from diia_scraper.validation import ValidationResult, assess_story_blocks
+
+
+class ValidationTests(unittest.TestCase):
+    def test_assess_story_blocks_marks_missing_sections(self) -> None:
+        blocks = {"Introduction": "Text", "Case Description": "", "Challenges": ""}
+        result = assess_story_blocks(blocks, ["Introduction", "Case Description", "Challenges"])
+        self.assertTrue(result.needs_review)
+        self.assertEqual(result.missing_blocks, ["Case Description", "Challenges"])
+        self.assertIn("Case Description", result.notes)
+        self.assertIn("Challenges", result.notes)
+
+    def test_validation_result_repr(self) -> None:
+        result = ValidationResult(missing_blocks=["A"], needs_review=True, notes={"A": "Missing"})
+        self.assertIn("A", repr(result))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a configurable scraping and structuring pipeline for Diia.Business success stories with CLI support
- implement heuristic story parsing, validation helpers, and JSON/CSV export utilities
- document usage, dependencies, and best practices in README

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68d8f84b63c88323ac42998675bbde3e